### PR TITLE
feat(documents): paginate workspace documents endpoint

### DIFF
--- a/src/document/document.controller.ts
+++ b/src/document/document.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Post, Body, Param, UseGuards, Patch, Delete } from '@nestjs/common';
-import { DocumentService, CreateDocumentDto, DocumentResponseDto } from './document.service';
+import { Controller, Get, Post, Body, Param, UseGuards, Patch, Delete, Query, ParseIntPipe } from '@nestjs/common';
+import { DocumentService, CreateDocumentDto, DocumentResponseDto, PaginatedDocumentsResponseDto } from './document.service';
 import { BulkDeleteDocumentsDto } from './dto/bulk-delete-documents.dto';
 import { DocumentDeletionPreviewDto } from './dto/document-deletion-preview.dto';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { InternalApiGuard } from 'src/auth/guards/internal-api.guard';
@@ -54,26 +54,37 @@ export class DocumentController {
   @Get('workspace/:workspaceId')
   @UseGuards(RolesGuard)
   @Roles(USER_ROLES.ADMIN, USER_ROLES.USER)
-  @ApiOperation({ summary: 'Get all documents in a workspace' })
+  @ApiOperation({ summary: 'Get documents in a workspace (paginated)' })
   @ApiParam({ name: 'workspaceId', description: 'Workspace ID' })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Items per page (default: 20)' })
   @ApiResponse({
     status: 200,
-    description: 'Return documents in the workspace.',
+    description: 'Return paginated documents in the workspace.',
     schema: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
-          fileName: { type: 'string' },
-          documentUrl: { type: 'string' },
-          type: { type: 'string', enum: Object.values(DocumentType) },
-          status: { type: 'string', enum: Object.values(DocumentStatus) },
-          uploadId: { type: 'string' },
-          userId: { type: 'string' },
-          createdAt: { type: 'string', format: 'date-time' },
-          updatedAt: { type: 'string', format: 'date-time' },
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              fileName: { type: 'string' },
+              documentUrl: { type: 'string' },
+              type: { type: 'string', enum: Object.values(DocumentType) },
+              status: { type: 'string', enum: Object.values(DocumentStatus) },
+              uploadId: { type: 'string' },
+              userId: { type: 'string' },
+              createdAt: { type: 'string', format: 'date-time' },
+              updatedAt: { type: 'string', format: 'date-time' },
+            },
+          },
         },
+        total: { type: 'number' },
+        page: { type: 'number' },
+        limit: { type: 'number' },
+        totalPages: { type: 'number' },
       },
     },
   })
@@ -82,8 +93,10 @@ export class DocumentController {
   findByWorkspace(
     @Param('workspaceId') workspaceId: string,
     @CurrentUser() user: JwtPayload,
-  ): Promise<DocumentResponseDto[]> {
-    return this.documentService.getDocumentsByWorkspace(workspaceId, user);
+    @Query('page', new ParseIntPipe({ optional: true })) page: number = 1,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit: number = 20,
+  ): Promise<PaginatedDocumentsResponseDto> {
+    return this.documentService.getDocumentsByWorkspace(workspaceId, user, page, limit);
   }
 
   @Delete('workspace/:workspaceId')

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -33,6 +33,14 @@ export interface DocumentResponseDto {
   updatedAt: Date;
 }
 
+export interface PaginatedDocumentsResponseDto {
+  data: DocumentResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 @Injectable()
 export class DocumentService {
   private readonly logger = new Logger(DocumentService.name);
@@ -131,34 +139,52 @@ export class DocumentService {
   async getDocumentsByWorkspace(
     workspaceId: string,
     user: JwtPayload,
-  ): Promise<DocumentResponseDto[]> {
+    page: number = 1,
+    limit: number = 20,
+  ): Promise<PaginatedDocumentsResponseDto> {
     try {
       // Verify workspace access
       await this.validateWorkspaceAccess(workspaceId, user);
 
-      const documents = await this.prisma.document.findMany({
-        where: {
-          workspace: {
-            some: {
-              workspaceId: workspaceId,
-            },
+      const skip = (page - 1) * limit;
+      const where = {
+        workspace: {
+          some: {
+            workspaceId: workspaceId,
           },
         },
-        select: {
-          id: true,
-          fileName: true,
-          documentUrl: true,
-          type: true,
-          status: true,
-          uploadId: true,
-          userId: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-        orderBy: { createdAt: 'desc' },
-      });
+      };
 
-      return documents;
+      const [documents, total] = await Promise.all([
+        this.prisma.document.findMany({
+          where,
+          skip,
+          take: limit,
+          select: {
+            id: true,
+            fileName: true,
+            documentUrl: true,
+            type: true,
+            status: true,
+            uploadId: true,
+            userId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+          orderBy: { createdAt: 'desc' },
+        }),
+        this.prisma.document.count({ where }),
+      ]);
+
+      const totalPages = Math.ceil(total / limit);
+
+      return {
+        data: documents,
+        total,
+        page,
+        limit,
+        totalPages,
+      };
     } catch (error: unknown) {
       if (error instanceof ForbiddenException || error instanceof NotFoundException) {
         throw error;


### PR DESCRIPTION
## Summary
`GET /documents/workspace/:workspaceId` previously returned **every** document in the workspace as a flat array. It now accepts `page`/`limit` query params (default `page=1`, `limit=20`) and returns the standard paginated shape `{ data, total, page, limit, totalPages }` using `skip`/`take` + `count`, matching the existing workspace/user/company pagination convention.

## ⚠️ Breaking change / merge order
This changes the response shape (array → object). The frontend PR consumes the new shape, so **merge/deploy this backend PR before** the frontend one (ImranAhmed26/devcom `OCR-add-document-pagination`).

## Testing
- [x] `tsc --noEmit` clean
- [ ] Manual: verify paged responses + total across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)