### PR TITLE
feat(document-editor): add OCR read + result edit endpoints

### DIFF
--- a/src/aws/s3-object/s3-object.module.ts
+++ b/src/aws/s3-object/s3-object.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { S3ObjectService } from './s3-object.service';
+
+// ConfigModule is registered globally in AppModule, so ConfigService is injectable here.
+@Module({
+  providers: [S3ObjectService],
+  exports: [S3ObjectService],
+})
+export class S3ObjectModule {}

--- a/src/aws/s3-object/s3-object.service.ts
+++ b/src/aws/s3-object/s3-object.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+/**
+ * Read-side S3 access for the Document Editor:
+ *  - presigned GET URLs for the original uploaded file (input bucket)
+ *  - reading the parsed Textract JSON written by the result Lambda (output bucket)
+ *
+ * Kept separate from S3UploadUrlService, which owns the write/upload path.
+ */
+@Injectable()
+export class S3ObjectService {
+  private readonly logger = new Logger(S3ObjectService.name);
+  private readonly s3: S3Client;
+  private readonly inputBucket: string;
+  private readonly outputBucket: string;
+  private readonly downloadUrlTtl = 900; // 15 minutes
+
+  constructor(private readonly config: ConfigService) {
+    this.s3 = new S3Client({
+      region: this.config.get<string>('AWS_REGION') as string,
+      credentials: {
+        accessKeyId: this.config.get<string>('AWS_ACCESS_KEY_ID') as string,
+        secretAccessKey: this.config.get<string>('AWS_SECRET_ACCESS_KEY') as string,
+      },
+    });
+    this.inputBucket = this.config.get<string>('S3_BUCKET_NAME') as string;
+    this.outputBucket = this.config.get<string>('TEXTRACT_OUTPUT_BUCKET') as string;
+  }
+
+  /**
+   * Presigned GET URL for viewing/downloading the original document file from the
+   * input bucket. Expires after `downloadUrlTtl` seconds.
+   */
+  async getDownloadUrl(key: string): Promise<string> {
+    const command = new GetObjectCommand({ Bucket: this.inputBucket, Key: key });
+    return getSignedUrl(this.s3, command, { expiresIn: this.downloadUrlTtl });
+  }
+
+  /**
+   * Fetch and parse a JSON object from the parsed/output bucket (the raw Textract
+   * result). Returns null on any failure so a missing/corrupt result never breaks
+   * the editor — the file viewer can still render without extracted data.
+   */
+  async getJson<T = unknown>(key: string): Promise<T | null> {
+    try {
+      const res = await this.s3.send(
+        new GetObjectCommand({ Bucket: this.outputBucket, Key: key }),
+      );
+      if (!res.Body) return null;
+      const body = await res.Body.transformToString();
+      return JSON.parse(body) as T;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to read parsed JSON from S3 (key=${key}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+}

--- a/src/document-result/document-result.controller.ts
+++ b/src/document-result/document-result.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Post, Body, Param, UseGuards, Patch } from '@nestjs/common';
 import { DocumentResultService } from './document-result.service';
 import { CreateDocumentResultDto } from './dto/create-document-result.dto';
+import { UpdateDocumentResultDto } from './dto/update-document-result.dto';
 import { DocumentResultResponseDto } from './dto/document-result-response.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
@@ -78,6 +79,30 @@ export class DocumentResultController {
   @ApiResponse({ status: 404, description: 'Document result not found' })
   async getById(@Param('id') id: string): Promise<DocumentResultResponseDto> {
     return this.documentResultService.getDocumentResultById(id);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @Roles(USER_ROLES.ADMIN, USER_ROLES.USER)
+  @ApiOperation({
+    summary: 'Edit document result (correct summary / line items)',
+    description:
+      'Persists corrections made in the Document Editor. Provided fields replace stored ' +
+      'values; items (when provided) fully replace the existing line items.',
+  })
+  @ApiParam({ name: 'id', description: 'Document result ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Document result updated successfully',
+    type: DocumentResultResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Document result not found' })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateDocumentResultDto,
+  ): Promise<DocumentResultResponseDto> {
+    return this.documentResultService.updateDocumentResult(id, dto);
   }
 
   @Patch(':id/status')

--- a/src/document-result/document-result.service.ts
+++ b/src/document-result/document-result.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateDocumentResultDto } from './dto/create-document-result.dto';
+import { UpdateDocumentResultDto } from './dto/update-document-result.dto';
 import { DocumentResultResponseDto } from './dto/document-result-response.dto';
 import { getErrorMessage, getErrorStack, getPrismaErrorCode } from 'src/common/types/error.types';
 import { DocumentStatus } from '@prisma/client';
@@ -324,6 +325,103 @@ export class DocumentResultService {
         getErrorStack(error),
       );
       throw new InternalServerErrorException('Failed to fetch document result');
+    }
+  }
+
+  /**
+   * Edit a document result from the Document Editor. Updates `summary` and/or fully
+   * replaces line `items` in a single transaction. Only provided fields are changed.
+   */
+  async updateDocumentResult(
+    id: string,
+    dto: UpdateDocumentResultDto,
+  ): Promise<DocumentResultResponseDto> {
+    try {
+      const existing = await this.prisma.documentResult.findUnique({
+        where: { id },
+        select: { id: true },
+      });
+
+      if (!existing) {
+        throw new NotFoundException(`Document result with ID ${id} not found`);
+      }
+
+      const result = await this.prisma.$transaction(async tx => {
+        if (dto.summary !== undefined) {
+          await tx.documentResult.update({
+            where: { id },
+            data: { summary: dto.summary as any },
+          });
+        }
+
+        if (dto.items !== undefined) {
+          // Replace existing line items with the corrected set.
+          await tx.invoiceItem.deleteMany({ where: { resultId: id } });
+          if (dto.items.length > 0) {
+            await tx.invoiceItem.createMany({
+              data: dto.items.map(item => ({
+                resultId: id,
+                name: item.name,
+                quantity: item.quantity,
+                unitPrice: item.unitPrice,
+                total: item.total,
+                tax: item.tax,
+              })),
+            });
+          }
+        }
+
+        return tx.documentResult.findUniqueOrThrow({
+          where: { id },
+          select: {
+            id: true,
+            jobId: true,
+            jsonUrl: true,
+            csvUrl: true,
+            createdAt: true,
+            summary: true,
+            status: true,
+            reviewedAt: true,
+            approvedAt: true,
+            approvedById: true,
+            items: {
+              select: {
+                id: true,
+                resultId: true,
+                name: true,
+                quantity: true,
+                unitPrice: true,
+                total: true,
+                tax: true,
+                createdAt: true,
+              },
+              orderBy: { createdAt: 'asc' },
+            },
+          },
+        });
+      });
+
+      this.logger.log(`Document result ${id} updated (summary/items edited)`);
+
+      return {
+        ...result,
+        summary: result.summary as Record<string, any> | null,
+      } as DocumentResultResponseDto;
+    } catch (error: unknown) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
+      const errorCode = getPrismaErrorCode(error);
+      if (errorCode === 'P2025') {
+        throw new NotFoundException(`Document result with ID ${id} not found`);
+      }
+
+      this.logger.error(
+        `Failed to update document result ${id}: ${getErrorMessage(error)}`,
+        getErrorStack(error),
+      );
+      throw new InternalServerErrorException('Failed to update document result');
     }
   }
 

--- a/src/document-result/dto/update-document-result.dto.ts
+++ b/src/document-result/dto/update-document-result.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsObject, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { InvoiceItemDto } from './invoice-item.dto';
+
+/**
+ * Payload for editing a document result from the Document Editor.
+ * Any provided field replaces the stored value; omitted fields are left untouched.
+ * `items`, when provided, fully replaces the existing line items.
+ */
+export class UpdateDocumentResultDto {
+  @ApiPropertyOptional({
+    description: 'Corrected summary fields (vendor, totals, dates, etc.)',
+    example: { vendorName: 'ACME Corp', invoiceTotal: '1100.00', invoiceDate: '2024-01-15' },
+  })
+  @IsObject()
+  @IsOptional()
+  summary?: Record<string, any>;
+
+  @ApiPropertyOptional({
+    description: 'Corrected line items. Replaces the existing items entirely.',
+    type: [InvoiceItemDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => InvoiceItemDto)
+  @IsOptional()
+  items?: InvoiceItemDto[];
+}

--- a/src/document/document.controller.ts
+++ b/src/document/document.controller.ts
@@ -1,5 +1,11 @@
 import { Controller, Get, Post, Body, Param, UseGuards, Patch, Delete, Query, ParseIntPipe } from '@nestjs/common';
-import { DocumentService, CreateDocumentDto, DocumentResponseDto, PaginatedDocumentsResponseDto } from './document.service';
+import {
+  DocumentService,
+  CreateDocumentDto,
+  DocumentResponseDto,
+  PaginatedDocumentsResponseDto,
+  DocumentOcrResponseDto,
+} from './document.service';
 import { BulkDeleteDocumentsDto } from './dto/bulk-delete-documents.dto';
 import { DocumentDeletionPreviewDto } from './dto/document-deletion-preview.dto';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
@@ -141,6 +147,26 @@ export class DocumentController {
   @ApiResponse({ status: 404, description: 'Document not found.' })
   findById(@Param('id') id: string, @CurrentUser() user: JwtPayload): Promise<DocumentResponseDto> {
     return this.documentService.getDocumentById(id, user);
+  }
+
+  @Get(':id/ocr')
+  @UseGuards(RolesGuard)
+  @Roles(USER_ROLES.ADMIN, USER_ROLES.USER)
+  @ApiOperation({
+    summary: 'Get bundled editor payload (file URL + OCR result + parsed data)',
+    description:
+      'Returns a presigned file URL, the editable document result (summary + line items), ' +
+      'and the raw parsed Textract JSON with bounding boxes. Powers the Document Editor.',
+  })
+  @ApiParam({ name: 'id', description: 'Document ID' })
+  @ApiResponse({ status: 200, description: 'Bundled document OCR payload.' })
+  @ApiResponse({ status: 403, description: 'Access denied to document.' })
+  @ApiResponse({ status: 404, description: 'Document not found.' })
+  getDocumentOcr(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<DocumentOcrResponseDto> {
+    return this.documentService.getDocumentOcr(id, user);
   }
 
   @Patch(':id/status')

--- a/src/document/document.module.ts
+++ b/src/document/document.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { DocumentService } from './document.service';
 import { DocumentController } from './document.controller';
 import { PrismaModule } from '../prisma/prisma.module';
+import { S3ObjectModule } from '../aws/s3-object/s3-object.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, S3ObjectModule],
   controllers: [DocumentController],
   providers: [DocumentService],
   exports: [DocumentService],

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -12,6 +12,7 @@ import { JwtPayload } from 'src/auth/interfaces/jwt-payload.interfaces';
 import { DocumentType, DocumentStatus } from '@prisma/client';
 import { OWNER_TYPES } from 'src/common/constants/enums';
 import { DocumentDeletionPreviewDto } from './dto/document-deletion-preview.dto';
+import { S3ObjectService } from '../aws/s3-object/s3-object.service';
 
 export interface CreateDocumentDto {
   uploadId: string;
@@ -41,11 +42,49 @@ export interface PaginatedDocumentsResponseDto {
   totalPages: number;
 }
 
+export interface DocumentOcrResultItemDto {
+  id: string;
+  name: string | null;
+  quantity: number | null;
+  unitPrice: number | null;
+  total: number | null;
+  tax: number | null;
+}
+
+export interface DocumentOcrResultDto {
+  id: string;
+  status: string;
+  summary: Record<string, any> | null;
+  items: DocumentOcrResultItemDto[];
+  reviewedAt: Date | null;
+  approvedAt: Date | null;
+}
+
+/**
+ * Bundled payload for the Document Editor: everything the editor needs in one call.
+ * `fileUrl` is a short-lived presigned GET; `result` is the editable DB-backed data;
+ * `parsed` is the raw Textract JSON (with bounding boxes) or null when unavailable.
+ */
+export interface DocumentOcrResponseDto {
+  document: {
+    id: string;
+    fileName: string;
+    type: DocumentType;
+    status: DocumentStatus;
+  };
+  fileUrl: string | null;
+  result: DocumentOcrResultDto | null;
+  parsed: unknown | null;
+}
+
 @Injectable()
 export class DocumentService {
   private readonly logger = new Logger(DocumentService.name);
 
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly s3Object: S3ObjectService,
+  ) {}
 
   async createDocument(data: CreateDocumentDto, user: JwtPayload): Promise<DocumentResponseDto> {
     try {
@@ -318,6 +357,121 @@ export class DocumentService {
         getErrorStack(error),
       );
       throw new InternalServerErrorException('Failed to fetch document');
+    }
+  }
+
+  /**
+   * Bundled payload for the Document Editor: presigned file URL + editable result +
+   * raw parsed Textract JSON. Resolves the document -> upload -> job -> result chain
+   * server-side so the frontend never needs to know about uploadId/jobId plumbing.
+   */
+  async getDocumentOcr(documentId: string, user: JwtPayload): Promise<DocumentOcrResponseDto> {
+    try {
+      const document = await this.prisma.document.findUnique({
+        where: { id: documentId },
+        select: {
+          id: true,
+          fileName: true,
+          type: true,
+          status: true,
+          userId: true,
+          workspace: { select: { workspaceId: true } },
+          upload: {
+            select: {
+              key: true,
+              job: {
+                select: {
+                  id: true,
+                  ocrJsonUrl: true,
+                  result: {
+                    select: {
+                      id: true,
+                      status: true,
+                      summary: true,
+                      reviewedAt: true,
+                      approvedAt: true,
+                      items: {
+                        select: {
+                          id: true,
+                          name: true,
+                          quantity: true,
+                          unitPrice: true,
+                          total: true,
+                          tax: true,
+                        },
+                        orderBy: { createdAt: 'asc' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!document) {
+        throw new NotFoundException(`Document with ID ${documentId} not found`);
+      }
+
+      // Access check: owner, admin, or a member of any workspace the document is in.
+      const isOwnerOrAdmin = document.userId === user.sub || user.role === 0;
+      if (!isOwnerOrAdmin) {
+        let hasAccess = false;
+        for (const ws of document.workspace) {
+          try {
+            await this.validateWorkspaceAccess(ws.workspaceId, user);
+            hasAccess = true;
+            break;
+          } catch {
+            // Try the next workspace association.
+          }
+        }
+        if (!hasAccess) {
+          throw new ForbiddenException('Access denied to this document');
+        }
+      }
+
+      const key = document.upload?.key;
+      const job = document.upload?.job;
+
+      const [fileUrl, parsed] = await Promise.all([
+        key ? this.s3Object.getDownloadUrl(key) : Promise.resolve(null),
+        job?.ocrJsonUrl ? this.s3Object.getJson(job.ocrJsonUrl) : Promise.resolve(null),
+      ]);
+
+      const result: DocumentOcrResultDto | null = job?.result
+        ? {
+            id: job.result.id,
+            status: job.result.status,
+            summary: job.result.summary as Record<string, any> | null,
+            items: job.result.items,
+            reviewedAt: job.result.reviewedAt,
+            approvedAt: job.result.approvedAt,
+          }
+        : null;
+
+      return {
+        document: {
+          id: document.id,
+          fileName: document.fileName,
+          type: document.type,
+          status: document.status,
+        },
+        fileUrl,
+        result,
+        parsed,
+      };
+    } catch (error: unknown) {
+      if (error instanceof NotFoundException || error instanceof ForbiddenException) {
+        throw error;
+      }
+
+      this.logger.error(
+        `Failed to fetch document OCR payload: ${getErrorMessage(error)}`,
+        getErrorStack(error),
+      );
+      throw new InternalServerErrorException('Failed to fetch document OCR payload');
     }
   }
 


### PR DESCRIPTION
Add the backend enablers for the full-page Document Editor:

- S3ObjectService: presigned GET URLs for original files (input bucket) and JSON reads of parsed Textract results (output bucket), kept separate from the upload/write path.
- GET /documents/:id/ocr: one call returning the presigned file URL, the editable document result (summary + line items), and the raw parsed Textract JSON with bounding boxes. Resolves the document -> upload -> job -> result chain server-side; access-checked (owner/admin/workspace).
- PATCH /document-results/:id: persist edited summary and replace line items in one transaction (review status flow via existing :id/status).

All endpoints are additive; existing behavior is unchanged.