### PR TITLE
fix(document-editor): map only curated canonical fields

### DIFF
--- a/src/document-result/textract.mapper.ts
+++ b/src/document-result/textract.mapper.ts
@@ -212,12 +212,11 @@ function mapExpense(docs: RawExpenseDoc[]): MappedResult {
     for (const f of doc.summaryFields ?? []) {
       const rawType = str(f.type);
       if (!rawType) continue;
-      const def = CANONICAL_FIELDS[rawType] ?? {
-        key: rawType,
-        label: humanize(rawType),
-        dataType: FieldDataType.STRING,
-      };
-      // Curated set is one row per canonical key; keep the first (highest-priority) hit.
+      // Curated model: keep only canonical fields. Everything else (granular address
+      // parts, OTHER, etc.) stays in the raw S3 JSON but isn't materialized here.
+      const def = CANONICAL_FIELDS[rawType];
+      if (!def) continue;
+      // One row per canonical key; keep the first (highest-priority) hit.
       if (seen.has(def.key)) continue;
       seen.add(def.key);
       fields.push({


### PR DESCRIPTION
Follow-up to #32, which was merged before this commit landed on the branch.

The expense mapper was persisting **every** Textract summary-field type, including
granular address parts (`ADDRESS`, `CITY`, `STATE`, `STREET`, `ZIP_CODE`, `NAME`,
`ADDRESS_BLOCK`), `OTHER`, and `TAX_PAYER_ID`. That produces duplicates
(`ADDRESS` == `VENDOR_ADDRESS`, `NAME` == `VENDOR_NAME`) and misleading dedup: the
flattened Textract JSON doesn't tag vendor-vs-customer, so keeping the first
occurrence per type silently dropped the customer's variants.

This restricts materialization to the curated canonical registry (`VENDOR_NAME`,
`CUSTOMER_NAME`, `INVOICE_NUMBER`, `TOTAL`, …). Non-canonical types stay in the raw
S3 JSON only. For the sample invoice this collapses 18 fields → the clean 9.

No schema change — safe to deploy without another `db push`. Reprocess a document
after deploy to see the curated field set.