### PR TITLE
feat(document-editor): address/amount/VAT-rate/tax-id extraction improvements

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,6 +188,7 @@ model ExtractedField {
   dataType      FieldDataType @default(STRING)
   detectedValue String? // original OCR value (immutable audit)
   value         String? // current value (edited, or equal to detectedValue)
+  numericValue  Float? // parsed numeric value for CURRENCY/NUMBER fields (value stays raw text)
   confidence    Float? // confidence of the detected value
   page          Int           @default(1)
   boundingBox   Json? // { left, top, width, height } normalized 0..1
@@ -213,6 +214,7 @@ model LineItem {
   unitPrice   Float?
   amount      Float?
   tax         Float?
+  taxRate     Float? // per-line VAT/tax rate as a percent (e.g. 10 for "10%"), when present
   productCode String?
 
   boundingBox Json? // whole-row box (EXPENSE_ROW) for mapping

--- a/src/document-result/document-result.service.ts
+++ b/src/document-result/document-result.service.ts
@@ -6,7 +6,7 @@ import {
   BadRequestException,
   ConflictException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma, FieldDataType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { S3ObjectService } from '../aws/s3-object/s3-object.service';
 import { CreateDocumentResultDto } from './dto/create-document-result.dto';
@@ -14,7 +14,10 @@ import { UpdateDocumentResultDto } from './dto/update-document-result.dto';
 import { DocumentResultResponseDto } from './dto/document-result-response.dto';
 import { getErrorMessage, getErrorStack, getPrismaErrorCode } from 'src/common/types/error.types';
 import { DocumentStatus } from '@prisma/client';
-import { canonicalFieldDef, mapTextractResult } from './textract.mapper';
+import { canonicalFieldDef, mapTextractResult, parseAmount } from './textract.mapper';
+
+// dataTypes whose edited value should be re-parsed into numericValue.
+const NUMERIC_TYPES = new Set<FieldDataType>([FieldDataType.CURRENCY, FieldDataType.NUMBER]);
 
 /** Shared select for returning a fully-populated result. */
 const RESULT_SELECT = {
@@ -37,6 +40,7 @@ const RESULT_SELECT = {
       dataType: true,
       detectedValue: true,
       value: true,
+      numericValue: true,
       confidence: true,
       page: true,
       boundingBox: true,
@@ -53,6 +57,7 @@ const RESULT_SELECT = {
       unitPrice: true,
       amount: true,
       tax: true,
+      taxRate: true,
       productCode: true,
       boundingBox: true,
       confidence: true,
@@ -161,6 +166,7 @@ export class DocumentResultService {
                 dataType: f.dataType,
                 detectedValue: f.detectedValue,
                 value: f.detectedValue, // current value starts equal to the detection
+                numericValue: f.numericValue,
                 confidence: f.confidence,
                 page: f.page,
                 boundingBox: jsonOrNull(f.boundingBox),
@@ -174,6 +180,7 @@ export class DocumentResultService {
                 unitPrice: li.unitPrice,
                 amount: li.amount,
                 tax: li.tax,
+                taxRate: li.taxRate,
                 productCode: li.productCode,
                 boundingBox: jsonOrNull(li.boundingBox),
                 confidence: li.confidence,
@@ -286,7 +293,7 @@ export class DocumentResultService {
         where: { id },
         select: {
           id: true,
-          fields: { select: { key: true, detectedValue: true } },
+          fields: { select: { key: true, detectedValue: true, dataType: true } },
           lineItems: { select: { rowIndex: true } },
         },
       });
@@ -296,6 +303,7 @@ export class DocumentResultService {
       }
 
       const detectedByKey = new Map(existing.fields.map(f => [f.key, f.detectedValue]));
+      const dataTypeByKey = new Map(existing.fields.map(f => [f.key, f.dataType]));
 
       await this.prisma.$transaction(async tx => {
         // --- Header fields: upsert corrected values by canonical key ---
@@ -304,10 +312,13 @@ export class DocumentResultService {
           const detected = detectedByKey.get(edit.key) ?? null;
           const isEdited = value !== detected;
           const def = canonicalFieldDef(edit.key);
+          const dataType = dataTypeByKey.get(edit.key) ?? def.dataType;
+          // Re-derive the stored numeric for money/number fields from the edited text.
+          const numericValue = NUMERIC_TYPES.has(dataType) ? parseAmount(value) : null;
 
           await tx.extractedField.upsert({
             where: { resultId_key: { resultId: id, key: edit.key } },
-            update: { value, isEdited },
+            update: { value, numericValue, isEdited },
             create: {
               resultId: id,
               key: def.key,
@@ -315,6 +326,7 @@ export class DocumentResultService {
               dataType: def.dataType,
               detectedValue: null,
               value,
+              numericValue,
               isEdited,
             },
           });
@@ -341,6 +353,7 @@ export class DocumentResultService {
                 unitPrice: r.unitPrice ?? null,
                 amount: r.amount ?? null,
                 tax: r.tax ?? null,
+                taxRate: r.taxRate ?? null,
                 productCode: r.productCode ?? null,
               },
               create: {
@@ -351,6 +364,7 @@ export class DocumentResultService {
                 unitPrice: r.unitPrice ?? null,
                 amount: r.amount ?? null,
                 tax: r.tax ?? null,
+                taxRate: r.taxRate ?? null,
                 productCode: r.productCode ?? null,
               },
             });

--- a/src/document-result/dto/extracted-field.dto.ts
+++ b/src/document-result/dto/extracted-field.dto.ts
@@ -37,6 +37,9 @@ export class ExtractedFieldResponseDto {
   @ApiPropertyOptional({ description: 'Current value (edited, or equal to detectedValue)' })
   value?: string | null;
 
+  @ApiPropertyOptional({ description: 'Parsed numeric value for CURRENCY/NUMBER fields' })
+  numericValue?: number | null;
+
   @ApiPropertyOptional({ description: 'Confidence of the detected value (0..100)' })
   confidence?: number | null;
 

--- a/src/document-result/dto/line-item.dto.ts
+++ b/src/document-result/dto/line-item.dto.ts
@@ -25,6 +25,9 @@ export class LineItemResponseDto {
   @ApiPropertyOptional()
   tax?: number | null;
 
+  @ApiPropertyOptional({ description: 'Per-line VAT/tax rate as a percent (e.g. 10 for 10%)' })
+  taxRate?: number | null;
+
   @ApiPropertyOptional()
   productCode?: string | null;
 
@@ -69,6 +72,11 @@ export class LineItemEditDto {
   @IsOptional()
   @IsNumber()
   tax?: number | null;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  taxRate?: number | null;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/src/document-result/textract.mapper.ts
+++ b/src/document-result/textract.mapper.ts
@@ -67,6 +67,7 @@ export interface MappedField {
   label: string | null;
   dataType: FieldDataType;
   detectedValue: string | null;
+  numericValue: number | null; // parsed number for CURRENCY/NUMBER fields, else null
   confidence: number | null;
   page: number;
   boundingBox: NormalizedBox | null;
@@ -79,6 +80,7 @@ export interface MappedLineItem {
   unitPrice: number | null;
   amount: number | null;
   tax: number | null;
+  taxRate: number | null; // per-line VAT/tax rate as a percent (e.g. 10 for "10%")
   productCode: string | null;
   boundingBox: NormalizedBox | null;
   confidence: number | null;
@@ -117,7 +119,14 @@ const CANONICAL_FIELDS: Record<string, CanonicalDef> = {
   AMOUNT_DUE: { key: 'AMOUNT_DUE', label: 'Amount due', dataType: FieldDataType.CURRENCY },
   AMOUNT_PAID: { key: 'AMOUNT_PAID', label: 'Amount paid', dataType: FieldDataType.CURRENCY },
   PAYMENT_TERMS: { key: 'PAYMENT_TERMS', label: 'Payment terms', dataType: FieldDataType.STRING },
+  // Textract emits one TAX_PAYER_ID per party (vendor + customer) with the same type.
+  // Without GroupProperties (dropped by the Lambda) we can't split them, so we keep the
+  // first occurrence — typically the vendor/supplier — as a single "Tax ID".
+  TAX_PAYER_ID: { key: 'TAX_ID', label: 'Tax ID', dataType: FieldDataType.STRING },
 };
+
+// dataTypes whose values should be parsed into a stored numeric.
+const NUMERIC_TYPES = new Set<FieldDataType>([FieldDataType.CURRENCY, FieldDataType.NUMBER]);
 
 /** Canonical definition for a header field key, used when creating an edited field
  *  that wasn't originally detected. Falls back to a STRING passthrough. */
@@ -144,8 +153,14 @@ function conf(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
-/** Parse a currency/number string like "$1,234.50" or "1.234,50" into a number. */
-function parseNumber(v: unknown): number | null {
+/**
+ * Parse a monetary/number string into a number. Shared by header currency fields and
+ * line-item columns. Deliberately locale-agnostic: strips currency symbols, spaces
+ * (incl. thin/non-breaking used as thousands separators) and other noise, then decides
+ * the decimal separator by "whichever of . or , appears last" — which handles both
+ * "1,234.50" and "1.234,50". Not a full i18n parser; good enough without locale data.
+ */
+export function parseAmount(v: unknown): number | null {
   const s = str(v);
   if (s === null) return null;
   // Strip everything except digits, separators and sign, then normalize separators.
@@ -162,6 +177,31 @@ function parseNumber(v: unknown): number | null {
   }
   const n = Number(cleaned);
   return Number.isFinite(n) ? n : null;
+}
+
+/** Parse a percentage cell like "10%" or "7,5 %" into its numeric rate (10, 7.5). */
+function parsePercent(v: unknown): number | null {
+  const s = str(v);
+  if (s === null || !s.includes('%')) return null;
+  return parseAmount(s.replace('%', ''));
+}
+
+/** Collapse newlines/runs of whitespace to single spaces (for one-line fields). */
+function normalizeInline(v: string | null): string | null {
+  if (v === null) return null;
+  const out = v.replace(/\s+/g, ' ').trim();
+  return out.length > 0 ? out : null;
+}
+
+/** Drop a leading name line from an address when it duplicates the entity name — Textract
+ *  returns the whole postal block (name included) as the address. */
+function stripLeadingName(address: string | null, name: string | null): string | null {
+  if (!address || !name) return address;
+  const lines = address.split(/\r?\n/);
+  if (lines.length > 1 && lines[0].trim() === name.trim()) {
+    return lines.slice(1).join('\n').trim() || address;
+  }
+  return address;
 }
 
 function humanize(key: string): string {
@@ -219,11 +259,13 @@ function mapExpense(docs: RawExpenseDoc[]): MappedResult {
       // One row per canonical key; keep the first (highest-priority) hit.
       if (seen.has(def.key)) continue;
       seen.add(def.key);
+      const detectedValue = str(f.value);
       fields.push({
         key: def.key,
         label: def.label,
         dataType: def.dataType,
-        detectedValue: str(f.value),
+        detectedValue,
+        numericValue: NUMERIC_TYPES.has(def.dataType) ? parseAmount(detectedValue) : null,
         confidence: conf(f.confidence),
         page: typeof f.page === 'number' ? f.page : 1,
         boundingBox: toBox(f.boundingBox),
@@ -233,6 +275,18 @@ function mapExpense(docs: RawExpenseDoc[]): MappedResult {
     for (const li of doc.lineItems ?? []) {
       lineItems.push(mapLineItem(li, rowIndex++));
     }
+  }
+
+  // Textract returns the full postal block (name line included) as the address. Since we
+  // capture the name separately, strip it so the address field isn't "Name\nStreet...".
+  const byKey = (k: string) => fields.find(f => f.key === k);
+  for (const [addrKey, nameKey] of [
+    ['VENDOR_ADDRESS', 'VENDOR_NAME'],
+    ['CUSTOMER_ADDRESS', 'CUSTOMER_NAME'],
+  ] as const) {
+    const addr = byKey(addrKey);
+    const name = byKey(nameKey);
+    if (addr) addr.detectedValue = stripLeadingName(addr.detectedValue, name?.detectedValue ?? null);
   }
 
   return { fields, lineItems };
@@ -251,13 +305,28 @@ function mapLineItem(li: RawLineItem, rowIndex: number): MappedLineItem {
 
   const row = li.EXPENSE_ROW;
   const item = li.ITEM;
+
+  // A per-line VAT/tax rate often lands in an untyped cell (e.g. OTHER = "10%"). Take the
+  // first percentage-looking cell as the rate; the raw cell is preserved in `cells`.
+  let taxRate: number | null = null;
+  for (const cell of Object.values(li)) {
+    const r = parsePercent(cell?.value);
+    if (r !== null) {
+      taxRate = r;
+      break;
+    }
+  }
+
   return {
     rowIndex,
-    description: str(item?.value),
-    quantity: parseNumber(li.QUANTITY?.value),
-    unitPrice: parseNumber(li.UNIT_PRICE?.value),
-    amount: parseNumber(li.PRICE?.value),
-    tax: parseNumber(li.TAX?.value),
+    // Item descriptions wrap across physical lines; Textract keeps the newlines. Collapse
+    // them to spaces for a clean one-line value (raw text stays in cells.ITEM).
+    description: normalizeInline(str(item?.value)),
+    quantity: parseAmount(li.QUANTITY?.value),
+    unitPrice: parseAmount(li.UNIT_PRICE?.value),
+    amount: parseAmount(li.PRICE?.value),
+    tax: parseAmount(li.TAX?.value),
+    taxRate,
     productCode: str(li.PRODUCT_CODE?.value),
     boundingBox: toBox(row?.boundingBox) ?? toBox(item?.boundingBox),
     confidence: conf(row?.confidence) ?? conf(item?.confidence),
@@ -282,6 +351,7 @@ function mapDocument(pages: RawPage[]): MappedResult {
         label,
         dataType: FieldDataType.STRING,
         detectedValue: str(kv.value),
+        numericValue: null,
         confidence: conf(kv.confidence),
         page,
         boundingBox: toBox(kv.boundingBox),

--- a/src/document-result/textract.mapper.ts
+++ b/src/document-result/textract.mapper.ts
@@ -26,6 +26,7 @@ interface RawSummaryField {
   confidence?: number;
   boundingBox?: RawBox;
   page?: number;
+  groupTypes?: string[]; // Textract GroupProperties: e.g. ["VENDOR"] | ["RECEIVER"]
 }
 
 interface RawLineItemCell {
@@ -119,19 +120,31 @@ const CANONICAL_FIELDS: Record<string, CanonicalDef> = {
   AMOUNT_DUE: { key: 'AMOUNT_DUE', label: 'Amount due', dataType: FieldDataType.CURRENCY },
   AMOUNT_PAID: { key: 'AMOUNT_PAID', label: 'Amount paid', dataType: FieldDataType.CURRENCY },
   PAYMENT_TERMS: { key: 'PAYMENT_TERMS', label: 'Payment terms', dataType: FieldDataType.STRING },
-  // Textract emits one TAX_PAYER_ID per party (vendor + customer) with the same type.
-  // Without GroupProperties (dropped by the Lambda) we can't split them, so we keep the
-  // first occurrence — typically the vendor/supplier — as a single "Tax ID".
-  TAX_PAYER_ID: { key: 'TAX_ID', label: 'Tax ID', dataType: FieldDataType.STRING },
 };
+
+// TAX_PAYER_ID is emitted once per party with the same Textract type; the party is only
+// distinguishable via GroupProperties (groupTypes), so it's resolved dynamically.
+const SUPPLIER_TAX_ID: CanonicalDef = { key: 'SUPPLIER_TAX_ID', label: 'Supplier tax ID', dataType: FieldDataType.STRING };
+const CUSTOMER_TAX_ID: CanonicalDef = { key: 'CUSTOMER_TAX_ID', label: 'Customer tax ID', dataType: FieldDataType.STRING };
 
 // dataTypes whose values should be parsed into a stored numeric.
 const NUMERIC_TYPES = new Set<FieldDataType>([FieldDataType.CURRENCY, FieldDataType.NUMBER]);
 
+/** Resolve a raw AnalyzeExpense summary type to a curated canonical field, using the
+ *  party group (VENDOR/RECEIVER) to split types that repeat per party. Returns null for
+ *  non-curated types (they stay in the raw S3 JSON only). */
+function resolveExpenseField(rawType: string, groupTypes: string[]): CanonicalDef | null {
+  if (rawType === 'TAX_PAYER_ID') {
+    return groupTypes.includes('RECEIVER') ? CUSTOMER_TAX_ID : SUPPLIER_TAX_ID;
+  }
+  return CANONICAL_FIELDS[rawType] ?? null;
+}
+
 /** Canonical definition for a header field key, used when creating an edited field
  *  that wasn't originally detected. Falls back to a STRING passthrough. */
 export function canonicalFieldDef(key: string): CanonicalDef {
-  const byCanonical = Object.values(CANONICAL_FIELDS).find(d => d.key === key);
+  const known = [...Object.values(CANONICAL_FIELDS), SUPPLIER_TAX_ID, CUSTOMER_TAX_ID];
+  const byCanonical = known.find(d => d.key === key);
   if (byCanonical) return byCanonical;
   return { key, label: humanize(key), dataType: FieldDataType.STRING };
 }
@@ -254,7 +267,7 @@ function mapExpense(docs: RawExpenseDoc[]): MappedResult {
       if (!rawType) continue;
       // Curated model: keep only canonical fields. Everything else (granular address
       // parts, OTHER, etc.) stays in the raw S3 JSON but isn't materialized here.
-      const def = CANONICAL_FIELDS[rawType];
+      const def = resolveExpenseField(rawType, f.groupTypes ?? []);
       if (!def) continue;
       // One row per canonical key; keep the first (highest-priority) hit.
       if (seen.has(def.key)) continue;

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -49,6 +49,7 @@ export interface DocumentOcrFieldDto {
   dataType: string;
   detectedValue: string | null;
   value: string | null;
+  numericValue: number | null;
   confidence: number | null;
   page: number;
   boundingBox: unknown;
@@ -63,6 +64,7 @@ export interface DocumentOcrLineItemDto {
   unitPrice: number | null;
   amount: number | null;
   tax: number | null;
+  taxRate: number | null;
   productCode: string | null;
   boundingBox: unknown;
   confidence: number | null;
@@ -417,6 +419,7 @@ export class DocumentService {
                           dataType: true,
                           detectedValue: true,
                           value: true,
+                          numericValue: true,
                           confidence: true,
                           page: true,
                           boundingBox: true,
@@ -433,6 +436,7 @@ export class DocumentService {
                           unitPrice: true,
                           amount: true,
                           tax: true,
+                          taxRate: true,
                           productCode: true,
                           boundingBox: true,
                           confidence: true,


### PR DESCRIPTION
Follow-up extraction improvements from review of real invoice data.

### Changes
- **Address name stripping** — Textract returns the full postal block (with the name line) as `VENDOR_ADDRESS`/`RECEIVER_ADDRESS`. We already capture the name separately, so the leading name line is now removed from the address value.
- **Shared `parseAmount()`** — one locale-agnostic parser for all monetary values (strips symbols/whitespace incl. thin/non-breaking spaces; decimal separator = whichever of `.`/`,` appears last, so both `1,234.50` and `1.234,50` work). Header `CURRENCY`/`NUMBER` fields now persist a parsed `numericValue` next to the raw `value`/`detectedValue`, re-derived when the value is edited.
- **Per-line VAT rate** — a percentage cell Textract types as `OTHER` (e.g. `"10%"`) is captured into `LineItem.taxRate`. No extra `AnalyzeDocument` call.
- **Description normalization** — multi-line item descriptions collapse to one line (raw text preserved in `cells.ITEM`).
- **Tax ID** — `TAX_PAYER_ID` added to the canonical set (`TAX_ID`, "Tax ID"). Only the first occurrence (supplier) is kept; splitting supplier vs customer requires the Textract `GroupProperties` the Lambda currently discards (tracked separately).

### Schema / deploy
Two **nullable** columns added — `ExtractedField.numericValue`, `LineItem.taxRate`. After deploy, run:

```
docker compose exec api npx prisma db push --accept-data-loss
```

(`--accept-data-loss` is required by the flag name but nothing is dropped — both columns are nullable additions.) Reprocess a document to populate them.