### PR TITLE
feat(document-editor): normalize dates into typed values

### DIFF
--- a/src/document-result/document-result.service.ts
+++ b/src/document-result/document-result.service.ts
@@ -6,7 +6,7 @@ import {
   BadRequestException,
   ConflictException,
 } from '@nestjs/common';
-import { Prisma, FieldDataType } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { S3ObjectService } from '../aws/s3-object/s3-object.service';
 import { CreateDocumentResultDto } from './dto/create-document-result.dto';
@@ -14,10 +14,7 @@ import { UpdateDocumentResultDto } from './dto/update-document-result.dto';
 import { DocumentResultResponseDto } from './dto/document-result-response.dto';
 import { getErrorMessage, getErrorStack, getPrismaErrorCode } from 'src/common/types/error.types';
 import { DocumentStatus } from '@prisma/client';
-import { canonicalFieldDef, mapTextractResult, parseAmount } from './textract.mapper';
-
-// dataTypes whose edited value should be re-parsed into numericValue.
-const NUMERIC_TYPES = new Set<FieldDataType>([FieldDataType.CURRENCY, FieldDataType.NUMBER]);
+import { canonicalFieldDef, deriveNumericValue, mapTextractResult } from './textract.mapper';
 
 /** Shared select for returning a fully-populated result. */
 const RESULT_SELECT = {
@@ -313,8 +310,8 @@ export class DocumentResultService {
           const isEdited = value !== detected;
           const def = canonicalFieldDef(edit.key);
           const dataType = dataTypeByKey.get(edit.key) ?? def.dataType;
-          // Re-derive the stored numeric for money/number fields from the edited text.
-          const numericValue = NUMERIC_TYPES.has(dataType) ? parseAmount(value) : null;
+          // Re-derive the stored numeric (amount for money/number, epoch-ms for dates).
+          const numericValue = deriveNumericValue(dataType, value);
 
           await tx.extractedField.upsert({
             where: { resultId_key: { resultId: id, key: edit.key } },

--- a/src/document-result/textract.mapper.ts
+++ b/src/document-result/textract.mapper.ts
@@ -225,6 +225,84 @@ function parsePercent(v: unknown): number | null {
   return parseAmount(s.replace('%', ''));
 }
 
+/** Expand a 2-digit year to a 4-digit one (>=70 -> 1900s, else 2000s). */
+function normalizeYear(y: number): number {
+  if (y >= 100) return y;
+  return y >= 70 ? 1900 + y : 2000 + y;
+}
+
+/** Build epoch-ms at UTC midnight, rejecting invalid/overflowing calendar dates. */
+function utcDate(year: number, month: number, day: number): number | null {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  const ms = Date.UTC(year, month - 1, day);
+  const d = new Date(ms);
+  // Reject overflow (e.g. 31 Feb rolling into March).
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+    return null;
+  }
+  return ms;
+}
+
+/**
+ * Parse a date string into epoch milliseconds at UTC midnight — the typed value stored on
+ * DATE fields (the raw string stays in detectedValue). Sorting/exports derive from this.
+ *
+ * Locale note: numeric dates are read DAY-FIRST (DD/MM/YY[YY]) — the common European
+ * invoice convention, consistent with the comma-decimal amounts we see — except when a
+ * 4-digit leading component marks an ISO year, or a component > 12 can only be the day.
+ * This is a pragmatic MVP heuristic, not full i18n; genuinely ambiguous inputs (both parts
+ * <= 12, e.g. 04/01/2017) default to day-first. Returns null if it isn't a valid date.
+ */
+export function parseDate(v: unknown): number | null {
+  const s = str(v);
+  if (s === null) return null;
+
+  // ISO-ish YYYY-MM-DD (optionally followed by time) — unambiguous.
+  const isoMatch = s.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
+  if (isoMatch) return utcDate(+isoMatch[1], +isoMatch[2], +isoMatch[3]);
+
+  // Numeric date with / . or - separators.
+  const numMatch = s.match(/^(\d{1,4})[/.\-](\d{1,2})[/.\-](\d{1,4})$/);
+  if (numMatch) {
+    const a = +numMatch[1];
+    const b = +numMatch[2];
+    const c = +numMatch[3];
+    if (numMatch[1].length === 4) {
+      // YYYY/MM/DD
+      return utcDate(a, b, c);
+    }
+    // Day-first by default; swap only when the first component can't be a day-of-month
+    // and the second can (a<=12 & b>12 -> the first is the month, e.g. 04/13/2017).
+    let day = a;
+    let month = b;
+    if (a <= 12 && b > 12) {
+      day = b;
+      month = a;
+    }
+    return utcDate(normalizeYear(c), month, day);
+  }
+
+  // Named-month formats ("13 Mar 2015", "March 13, 2015") — best effort via the engine,
+  // re-projected onto UTC midnight so it matches the numeric paths.
+  const parsed = Date.parse(s);
+  if (Number.isFinite(parsed)) {
+    const d = new Date(parsed);
+    return utcDate(d.getFullYear(), d.getMonth() + 1, d.getDate());
+  }
+  return null;
+}
+
+/**
+ * The single source of truth for a field's stored numeric value. Currency/number fields
+ * parse to their amount; date fields parse to epoch-ms; everything else has none. Used by
+ * both the initial mapping and edit re-derivation so the two never drift.
+ */
+export function deriveNumericValue(dataType: FieldDataType, raw: unknown): number | null {
+  if (NUMERIC_TYPES.has(dataType)) return parseAmount(raw);
+  if (dataType === FieldDataType.DATE) return parseDate(raw);
+  return null;
+}
+
 /** Collapse newlines/runs of whitespace to single spaces (for one-line fields). */
 function normalizeInline(v: string | null): string | null {
   if (v === null) return null;
@@ -348,7 +426,7 @@ function mapExpense(docs: RawExpenseDoc[]): MappedResult {
         label: def.label,
         dataType: def.dataType,
         detectedValue,
-        numericValue: NUMERIC_TYPES.has(def.dataType) ? parseAmount(detectedValue) : null,
+        numericValue: deriveNumericValue(def.dataType, detectedValue),
         confidence: conf(f.confidence),
         page: typeof f.page === 'number' ? f.page : 1,
         boundingBox: toBox(f.boundingBox),


### PR DESCRIPTION
Completes **number/date normalization** — the currency/number half already parses into `numericValue`; this adds the DATE half.

## What
- **`parseDate()`** — parses a date string to **epoch-ms at UTC midnight**. Numeric dates are read **day-first** (`DD/MM/YY[YY]`, the common European invoice convention, consistent with the comma-decimal amounts in our sample data), with disambiguation when a component is `> 12`, plus ISO (`YYYY-MM-DD`) and named-month paths. Invalid/overflowing dates (e.g. `31 Feb`) return `null`.
- **`deriveNumericValue(dataType, raw)`** — single source of truth for a field's stored numeric: amount for CURRENCY/NUMBER, epoch-ms for DATE. Used by both the initial mapping and the edit re-derivation so the two paths can't drift.

## Storage
Raw string stays in `detectedValue`/`value` (so `isEdited` semantics are unchanged); the typed value reuses the existing `numericValue` column — **no schema change, no `db push` needed**.

## Verified
`parseDate` checked against the real sample dates: `13/02/15 → 2015-02-13`, `04/01/2017 → 2017-01-04`, `03-15-2016 → 2016-03-15`, `31/02/2020 → null`, ISO + named-month formats. Backend typechecks clean.