### PR TITLE
chore(s3): shorten presigned file URL TTL to 2 minutes

### DIFF
--- a/src/aws/s3-object/s3-object.service.ts
+++ b/src/aws/s3-object/s3-object.service.ts
@@ -16,7 +16,9 @@ export class S3ObjectService {
   private readonly s3: S3Client;
   private readonly inputBucket: string;
   private readonly outputBucket: string;
-  private readonly downloadUrlTtl = 900; // 15 minutes
+  // Short TTL: the presigned URL only needs to survive the editor's initial file load.
+  // Kept tight so a leaked/shared link (it's a bearer URL) stops working quickly.
+  private readonly downloadUrlTtl = 120; // 2 minutes
 
   constructor(private readonly config: ConfigService) {
     // Trim env values: a stray space or CRLF newline in a bucket name makes the AWS


### PR DESCRIPTION
The editor's presigned S3 GET URL was valid for **15 minutes**, but it only needs to survive the viewer's initial file load. Since a presigned URL is a **bearer link** (anyone holding it can fetch the object until it expires), drop the TTL to **120s** to shrink the window in which a leaked or shared link keeps working.

One-line config change in `S3ObjectService.downloadUrlTtl`; no new surface area. Independent of #38.

Trade-off: opening the image in a new tab more than ~2 min after loading the editor will 403 (the app refetches a fresh URL on reload). Acceptable — chosen over adding a streaming-proxy endpoint for now.