### PR TITLE
feat(auth): Sign in with Google (ID-token verification + account linking)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ SQS_QUEUE_URL=
 
 # JWT
 JWT_SECRET=your-jwt-secret-key-here
+JWT_REFRESH_SECRET=your-jwt-refresh-secret-key-here
+
+# Google Sign-In — OAuth 2.0 Web client ID from Google Cloud Console.
+# Must match NEXT_PUBLIC_GOOGLE_CLIENT_ID on the frontend (used as the ID-token audience).
+GOOGLE_CLIENT_ID=your-google-oauth-web-client-id.apps.googleusercontent.com
 
 # Internal API Key for AWS operations
 INTERNAL_API_KEY=your-internal-api-key-here

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "google-auth-library": "^10.9.0",
         "mime-types": "^3.0.1",
         "multer": "^2.0.0",
         "passport": "^0.7.0",
@@ -7532,6 +7533,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7913,7 +7923,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7942,6 +7951,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bin-version": {
@@ -8783,6 +8801,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -9537,6 +9564,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -9693,6 +9726,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -9973,6 +10029,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -10060,6 +10128,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -10213,6 +10309,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -10378,6 +10521,19 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -11465,6 +11621,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -12149,6 +12314,26 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -12157,6 +12342,24 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp-build": {
@@ -14844,6 +15047,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "google-auth-library": "^10.9.0",
     "mime-types": "^3.0.1",
     "multer": "^2.0.0",
     "passport": "^0.7.0",

--- a/prisma/migrations/20260719033812_add_google_auth/migration.sql
+++ b/prisma/migrations/20260719033812_add_google_auth/migration.sql
@@ -1,0 +1,12 @@
+-- Support Google (OAuth) accounts and account linking.
+
+-- Password is optional now: OAuth-only accounts have no password.
+ALTER TABLE "User" ALTER COLUMN "password" DROP NOT NULL;
+
+-- Google profile picture + linked Google account subject + verification flag.
+ALTER TABLE "User" ADD COLUMN "image" TEXT;
+ALTER TABLE "User" ADD COLUMN "googleId" TEXT;
+ALTER TABLE "User" ADD COLUMN "emailVerified" BOOLEAN NOT NULL DEFAULT false;
+
+-- One Google account maps to at most one user.
+CREATE UNIQUE INDEX "User_googleId_key" ON "User"("googleId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,12 +9,15 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  name      String
-  password  String
-  role      Int      @default(2) // 0=ADMIN, 1=INTERNAL, 2=USER
-  createdAt DateTime @default(now())
+  id            String   @id @default(uuid())
+  email         String   @unique
+  name          String
+  password      String?  // null for accounts created via an OAuth provider (e.g. Google)
+  role          Int      @default(2) // 0=ADMIN, 1=INTERNAL, 2=USER
+  image         String?  // profile picture URL (e.g. from Google)
+  googleId      String?  @unique // Google account subject ("sub"); set when linked
+  emailVerified Boolean  @default(false)
+  createdAt     DateTime @default(now())
 
   // 🔁 Belongs to a company (if not solo)
   companyId String?

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { RefreshDto } from './dto/refresh.dto';
+import { GoogleLoginDto } from './dto/google-login.dto';
 import { ApiTags, ApiResponse, ApiOperation } from '@nestjs/swagger';
 import { AuthResponseDto } from './dto/auth-response.dto';
 
@@ -39,6 +40,21 @@ export class AuthController {
   })
   register(@Body() dto: RegisterDto): Promise<AuthResponseDto> {
     return this.authService.register(dto);
+  }
+
+  @Post('google')
+  @ApiOperation({ summary: 'Sign in or sign up with a Google ID token' })
+  @ApiResponse({
+    status: 201,
+    description: 'Google sign-in successful',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Invalid or unverified Google credential',
+  })
+  googleLogin(@Body() dto: GoogleLoginDto): Promise<AuthResponseDto> {
+    return this.authService.googleLogin(dto.idToken);
   }
 
   @Post('refresh')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,17 +1,20 @@
 import {
   BadRequestException,
   Injectable,
+  InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { JwtService } from '@nestjs/jwt';
+import { OAuth2Client, type TokenPayload } from 'google-auth-library';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import * as bcrypt from 'bcrypt';
 import { jwtConstants } from './constants';
 import { UserService } from 'src/user/user.service';
 import { AuthResponseDto } from './dto/auth-response.dto';
-import { USER_TYPES } from 'src/common/constants/enums';
+import { USER_ROLES, USER_TYPES } from 'src/common/constants/enums';
 
 interface RefreshTokenPayload {
   sub: string;
@@ -19,10 +22,13 @@ interface RefreshTokenPayload {
 
 @Injectable()
 export class AuthService {
+  private googleClient?: OAuth2Client;
+
   constructor(
     private prisma: PrismaService,
     private jwt: JwtService,
     private userService: UserService,
+    private config: ConfigService,
   ) {}
 
   /** User registration */
@@ -54,6 +60,13 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    // Accounts created via Google have no password — they must use "Sign in with Google".
+    if (!user.password) {
+      throw new UnauthorizedException(
+        'This account uses Google sign-in. Please continue with Google.',
+      );
+    }
+
     const passwordMatch = await bcrypt.compare(dto.password, user.password);
     if (!passwordMatch) {
       throw new UnauthorizedException('Invalid credentials');
@@ -61,7 +74,92 @@ export class AuthService {
 
     const userType = this.determineUserType(user);
 
-    return this.signToken(user.id, user.email, user.role, user.name, userType);
+    return this.signToken(
+      user.id,
+      user.email,
+      user.role,
+      user.name,
+      userType,
+      user.image,
+      user.emailVerified,
+    );
+  }
+
+  /**
+   * Google sign-in / sign-up.
+   *
+   * Verifies the Google ID token, then finds-or-creates the user by email:
+   * - New email  -> create a Google-only account (no password, verified, picture set).
+   * - Existing email registered with a password -> link it (set googleId, backfill the
+   *   picture only if missing, mark verified) so the user is never duplicated.
+   * - Already linked -> just sign in.
+   */
+  async googleLogin(idToken: string): Promise<AuthResponseDto> {
+    const clientId = this.config.get<string>('GOOGLE_CLIENT_ID');
+    if (!clientId) {
+      throw new InternalServerErrorException('Google sign-in is not configured');
+    }
+
+    let payload: TokenPayload | undefined;
+    try {
+      const client = this.getGoogleClient(clientId);
+      const ticket = await client.verifyIdToken({ idToken, audience: clientId });
+      payload = ticket.getPayload();
+    } catch {
+      throw new UnauthorizedException('Invalid Google credential');
+    }
+
+    if (!payload?.email) {
+      throw new UnauthorizedException('Google account did not provide an email');
+    }
+    if (!payload.email_verified) {
+      throw new UnauthorizedException('Google email is not verified');
+    }
+
+    const googleId = payload.sub;
+    const email = payload.email.toLowerCase();
+    const picture = payload.picture ?? null;
+    const name = payload.name?.trim() || email.split('@')[0];
+
+    const existing = await this.prisma.user.findUnique({
+      where: { email },
+      include: { ownedCompany: true, company: true },
+    });
+
+    const user = existing
+      ? await this.prisma.user.update({
+          where: { id: existing.id },
+          // Keep an already-linked googleId and a user-set picture; never overwrite the name.
+          data: {
+            googleId: existing.googleId ?? googleId,
+            image: existing.image ?? picture,
+            emailVerified: true,
+          },
+          include: { ownedCompany: true, company: true },
+        })
+      : await this.prisma.user.create({
+          data: {
+            email,
+            name,
+            googleId,
+            image: picture,
+            emailVerified: true,
+            role: USER_ROLES.USER,
+          },
+          include: { ownedCompany: true, company: true },
+        });
+
+    const userType = this.determineUserType(user);
+
+    return this.signToken(
+      user.id,
+      user.email,
+      user.role,
+      user.name,
+      userType,
+      user.image,
+      user.emailVerified,
+    );
   }
 
   /** Refresh token logic */
@@ -82,10 +180,26 @@ export class AuthService {
 
       const userType = this.determineUserType(user);
 
-      return this.signToken(user.id, user.email, user.role, user.name, userType);
+      return this.signToken(
+        user.id,
+        user.email,
+        user.role,
+        user.name,
+        userType,
+        user.image,
+        user.emailVerified,
+      );
     } catch {
       throw new UnauthorizedException('Invalid refresh token');
     }
+  }
+
+  /** Lazily create (and cache) the Google OAuth client used to verify ID tokens. */
+  private getGoogleClient(clientId: string): OAuth2Client {
+    if (!this.googleClient) {
+      this.googleClient = new OAuth2Client(clientId);
+    }
+    return this.googleClient;
   }
 
   /** Determines user type (company owner, company user, freelancer) */
@@ -106,6 +220,8 @@ export class AuthService {
     role: number,
     name: string,
     userType: number,
+    image?: string | null,
+    emailVerified?: boolean,
   ): AuthResponseDto {
     const payload = { sub: userId, email, role };
 
@@ -118,7 +234,7 @@ export class AuthService {
         secret: jwtConstants.refreshSecret,
         expiresIn: '7d',
       }),
-      user: { id: userId, name, email, role, userType },
+      user: { id: userId, name, email, role, userType, image, emailVerified },
     };
   }
 }

--- a/src/auth/dto/auth-response.dto.ts
+++ b/src/auth/dto/auth-response.dto.ts
@@ -22,6 +22,12 @@ export class UserDto {
     enum: Object.values(USER_TYPES),
   })
   userType!: number;
+
+  @ApiProperty({ required: false, nullable: true, description: 'Profile picture URL' })
+  image?: string | null;
+
+  @ApiProperty({ required: false, description: 'Whether the email address is verified' })
+  emailVerified?: boolean;
 }
 
 export class AuthResponseDto {

--- a/src/auth/dto/google-login.dto.ts
+++ b/src/auth/dto/google-login.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GoogleLoginDto {
+  @ApiProperty({
+    description: 'The Google ID token (JWT credential) obtained on the client from Google Identity Services',
+  })
+  @IsString()
+  @IsNotEmpty()
+  idToken!: string;
+}


### PR DESCRIPTION
## Sign in with Google

Adds `POST /auth/google` so users can sign in / sign up with Google. The client (see the frontend PR) obtains a Google **ID token** via Google Identity Services and posts it here; the backend verifies it with `google-auth-library` (audience = `GOOGLE_CLIENT_ID`) and returns the **same** `{ access_token, refresh_token, user }` shape as email/password login — no new token format, no redirect/callback flow.

### Account resolution (by verified email)
Handles the edge cases explicitly so a person is never duplicated:

| Situation | Behaviour |
|---|---|
| Email not seen before | Create a Google-only account (no password, `emailVerified: true`, profile picture stored) |
| Email already registered **with a password** | **Link** the Google account: set `googleId`, backfill `image` only if missing, mark verified. The user's chosen name is never overwritten. |
| Already linked (googleId present) | Sign in |

Other guards:
- Rejects Google tokens whose `email_verified` is false.
- Rejects invalid/malformed credentials (`401`).
- Password login now rejects Google-only accounts with a clear "continue with Google" message (instead of a generic invalid-credentials error).

### Schema
`User.password` is now **nullable** (OAuth accounts have none). New columns: `image`, `googleId` (unique), `emailVerified` (default false). Migration: `add_google_auth`.

> **Note:** the active `DATABASE_URL` points at the managed (remote) Postgres, so I did **not** run `migrate dev` here. The migration SQL is hand-written to match exactly what Prisma generates; apply it with `npx prisma migrate deploy` on the normal deploy path. `prisma generate` has been run so the client types are current.

### Config
Adds `GOOGLE_CLIENT_ID` to `.env.example` (and documents `JWT_REFRESH_SECRET`). Set `GOOGLE_CLIENT_ID` to the OAuth 2.0 **Web** client ID from Google Cloud Console — it must equal the frontend's `NEXT_PUBLIC_GOOGLE_CLIENT_ID`.

### Verification
`npm run build` (nest build) passes. Runtime verification of the live Google flow requires a real `GOOGLE_CLIENT_ID` + the migration applied.
